### PR TITLE
Add reusable ImageCarousel and ImageLightbox components

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,14 @@
     "@tanstack/react-router": "^1.156.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "embla-carousel-react": "^8.6.0",
     "ky": "^1.14.3",
     "lucide-react": "^0.511.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.0.0",
+    "yet-another-react-lightbox": "^3.28.0",
     "zod": "^4.3.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      embla-carousel-react:
+        specifier: ^8.6.0
+        version: 8.6.0(react@19.2.3)
       ky:
         specifier: ^1.14.3
         version: 1.14.3
@@ -62,6 +65,9 @@ importers:
       tailwind-merge:
         specifier: ^3.0.0
         version: 3.4.0
+      yet-another-react-lightbox:
+        specifier: ^3.28.0
+        version: 3.28.0(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       zod:
         specifier: ^4.3.0
         version: 4.3.6
@@ -2051,6 +2057,19 @@ packages:
   electron-to-chromium@1.5.278:
     resolution: {integrity: sha512-dQ0tM1svDRQOwxnXxm+twlGTjr9Upvt8UFWAgmLsxEzFQxhbti4VwxmMjsDxVC51Zo84swW7FVCXEV+VAkhuPw==}
 
+  embla-carousel-react@8.6.0:
+    resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
+  embla-carousel-reactive-utils@8.6.0:
+    resolution: {integrity: sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0:
+    resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -3499,6 +3518,20 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yet-another-react-lightbox@3.28.0:
+    resolution: {integrity: sha512-bHjG1/DS4aWPkKb/6hNp0+zcgjda27wQlXBpJvb9TcblC1U1dY3Ih0pe85O8/ZLz+OIy+ZvLxN2gmsbDW0Q/QQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@types/react': ^16 || ^17 || ^18 || ^19
+      '@types/react-dom': ^16 || ^17 || ^18 || ^19
+      react: ^16.8.0 || ^17 || ^18 || ^19
+      react-dom: ^16.8.0 || ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -5328,6 +5361,18 @@ snapshots:
 
   electron-to-chromium@1.5.278: {}
 
+  embla-carousel-react@8.6.0(react@19.2.3):
+    dependencies:
+      embla-carousel: 8.6.0
+      embla-carousel-reactive-utils: 8.6.0(embla-carousel@8.6.0)
+      react: 19.2.3
+
+  embla-carousel-reactive-utils@8.6.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0: {}
+
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
@@ -6700,6 +6745,14 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yet-another-react-lightbox@3.28.0(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.9
+      '@types/react-dom': 19.2.3(@types/react@19.2.9)
 
   yocto-queue@0.1.0: {}
 

--- a/src/components/__tests__/image-carousel.test.tsx
+++ b/src/components/__tests__/image-carousel.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { ImageRead } from "@/api/generated/types"
+import { ImageCarousel } from "../image-carousel"
+
+function makeImage(overrides: Partial<ImageRead> = {}): ImageRead {
+  return {
+    id: crypto.randomUUID(),
+    item_id: null,
+    mark_id: null,
+    filename: "photo.jpg",
+    url: "https://example.com/photo.jpg",
+    content_type: "image/jpeg",
+    size_bytes: 1024,
+    position: 0,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+describe("ImageCarousel", () => {
+  it("renders placeholder when images array is empty", () => {
+    const { container } = render(<ImageCarousel images={[]} />)
+    // lucide icons render as svg with aria-hidden; query by class instead
+    expect(container.querySelector(".lucide-image-off")).toBeInTheDocument()
+  })
+
+  it("renders a single image without carousel controls", () => {
+    const image = makeImage({ filename: "solo.jpg", url: "/solo.jpg" })
+    render(<ImageCarousel images={[image]} showDots />)
+    expect(screen.getByAltText("solo.jpg")).toBeInTheDocument()
+    // No dot indicators for a single image
+    expect(
+      screen.queryByRole("button", { name: /go to slide/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders dot indicators for multiple images when showDots is true", () => {
+    const images = [
+      makeImage({ id: "1", filename: "a.jpg" }),
+      makeImage({ id: "2", filename: "b.jpg" }),
+      makeImage({ id: "3", filename: "c.jpg" }),
+    ]
+    render(<ImageCarousel images={images} showDots />)
+    const dots = screen.getAllByRole("button", { name: /go to slide/i })
+    expect(dots).toHaveLength(3)
+  })
+
+  it("does not render dots when showDots is false", () => {
+    const images = [makeImage({ id: "1" }), makeImage({ id: "2" })]
+    render(<ImageCarousel images={images} showDots={false} />)
+    expect(
+      screen.queryByRole("button", { name: /go to slide/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("calls onImageClick with the correct index", async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    const image = makeImage({ filename: "click-me.jpg", url: "/click.jpg" })
+    render(<ImageCarousel images={[image]} onImageClick={onClick} />)
+    await user.click(screen.getByAltText("click-me.jpg"))
+    expect(onClick).toHaveBeenCalledWith(0)
+  })
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <ImageCarousel images={[]} className="custom-class" />
+    )
+    expect(container.firstChild).toHaveClass("custom-class")
+  })
+})

--- a/src/components/__tests__/image-lightbox.test.tsx
+++ b/src/components/__tests__/image-lightbox.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest"
+import { render } from "@testing-library/react"
+import type { ImageRead } from "@/api/generated/types"
+import { ImageLightbox } from "../image-lightbox"
+
+function makeImage(overrides: Partial<ImageRead> = {}): ImageRead {
+  return {
+    id: crypto.randomUUID(),
+    item_id: null,
+    mark_id: null,
+    filename: "photo.jpg",
+    url: "https://example.com/photo.jpg",
+    content_type: "image/jpeg",
+    size_bytes: 1024,
+    position: 0,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+describe("ImageLightbox", () => {
+  it("renders nothing when open is false", () => {
+    const { container } = render(
+      <ImageLightbox
+        images={[makeImage()]}
+        open={false}
+        index={0}
+        onClose={vi.fn()}
+      />
+    )
+    // YARL does not render the lightbox overlay when closed
+    expect(container.querySelector(".yarl__root")).not.toBeInTheDocument()
+  })
+
+  it("renders the lightbox when open is true", () => {
+    render(
+      <ImageLightbox
+        images={[makeImage({ url: "/test.jpg", filename: "test.jpg" })]}
+        open={true}
+        index={0}
+        onClose={vi.fn()}
+      />
+    )
+    expect(document.querySelector(".yarl__root")).toBeInTheDocument()
+  })
+
+  it("renders a close button when open", () => {
+    render(
+      <ImageLightbox
+        images={[makeImage()]}
+        open={true}
+        index={0}
+        onClose={vi.fn()}
+      />
+    )
+    const closeButton = document.querySelector('button[aria-label="Close"]')
+    expect(closeButton).toBeInTheDocument()
+  })
+
+  it("renders with multiple images", () => {
+    const images = [
+      makeImage({ id: "1", url: "/a.jpg" }),
+      makeImage({ id: "2", url: "/b.jpg" }),
+      makeImage({ id: "3", url: "/c.jpg" }),
+    ]
+    render(
+      <ImageLightbox images={images} open={true} index={1} onClose={vi.fn()} />
+    )
+    expect(document.querySelector(".yarl__root")).toBeInTheDocument()
+  })
+})

--- a/src/components/image-carousel.tsx
+++ b/src/components/image-carousel.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useState } from "react"
+import useEmblaCarousel from "embla-carousel-react"
+import { ImageOff } from "lucide-react"
+import type { ImageRead } from "@/api/generated/types"
+import { cn } from "@/lib/utils"
+
+interface ImageCarouselProps {
+  images: ImageRead[]
+  aspectRatio?: string
+  showDots?: boolean
+  onImageClick?: (index: number) => void
+  className?: string
+}
+
+export function ImageCarousel({
+  images,
+  aspectRatio = "aspect-video",
+  showDots = false,
+  onImageClick,
+  className,
+}: ImageCarouselProps) {
+  const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true })
+  const [selectedIndex, setSelectedIndex] = useState(0)
+
+  const onSelect = useCallback(() => {
+    if (!emblaApi) return
+    setSelectedIndex(emblaApi.selectedScrollSnap())
+  }, [emblaApi])
+
+  useEffect(() => {
+    if (!emblaApi) return
+    onSelect()
+    emblaApi.on("select", onSelect)
+    return () => {
+      emblaApi.off("select", onSelect)
+    }
+  }, [emblaApi, onSelect])
+
+  if (images.length === 0) {
+    return (
+      <div
+        className={cn(
+          "bg-muted flex items-center justify-center rounded-lg",
+          aspectRatio,
+          className
+        )}
+      >
+        <ImageOff className="text-muted-foreground h-8 w-8" />
+      </div>
+    )
+  }
+
+  if (images.length === 1) {
+    return (
+      <div className={cn("overflow-hidden rounded-lg", className)}>
+        <div className={cn("relative", aspectRatio)}>
+          <img
+            src={images[0].url}
+            alt={images[0].filename}
+            className={cn(
+              "absolute inset-0 h-full w-full object-cover",
+              onImageClick && "cursor-pointer"
+            )}
+            onClick={() => onImageClick?.(0)}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn("relative", className)}>
+      <div ref={emblaRef} className="overflow-hidden rounded-lg">
+        <div className="flex">
+          {images.map((image, index) => (
+            <div key={image.id} className="min-w-0 flex-[0_0_100%]">
+              <div className={cn("relative", aspectRatio)}>
+                <img
+                  src={image.url}
+                  alt={image.filename}
+                  className={cn(
+                    "absolute inset-0 h-full w-full object-cover",
+                    onImageClick && "cursor-pointer"
+                  )}
+                  onClick={() => onImageClick?.(index)}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      {showDots && images.length > 1 && (
+        <div className="mt-2 flex justify-center gap-1.5">
+          {images.map((_, index) => (
+            <button
+              key={index}
+              type="button"
+              aria-label={`Go to slide ${index + 1}`}
+              className={cn(
+                "h-1.5 rounded-full transition-all",
+                index === selectedIndex
+                  ? "bg-primary w-3"
+                  : "bg-muted-foreground/30 w-1.5"
+              )}
+              onClick={() => emblaApi?.scrollTo(index)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/image-lightbox.tsx
+++ b/src/components/image-lightbox.tsx
@@ -1,0 +1,35 @@
+import Lightbox from "yet-another-react-lightbox"
+import Zoom from "yet-another-react-lightbox/plugins/zoom"
+import Thumbnails from "yet-another-react-lightbox/plugins/thumbnails"
+import "yet-another-react-lightbox/styles.css"
+import "yet-another-react-lightbox/plugins/thumbnails.css"
+import type { ImageRead } from "@/api/generated/types"
+
+interface ImageLightboxProps {
+  images: ImageRead[]
+  open: boolean
+  index: number
+  onClose: () => void
+}
+
+export function ImageLightbox({
+  images,
+  open,
+  index,
+  onClose,
+}: ImageLightboxProps) {
+  return (
+    <Lightbox
+      open={open}
+      close={onClose}
+      index={index}
+      slides={images.map((img) => ({
+        src: img.url,
+        alt: img.filename,
+      }))}
+      plugins={[Zoom, Thumbnails]}
+      thumbnails={{ position: "bottom", width: 80, height: 60 }}
+      zoom={{ maxZoomPixelRatio: 3 }}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- Install `embla-carousel-react` and `yet-another-react-lightbox` as new dependencies
- Add `ImageCarousel` component with swipe/drag support, dot indicators, empty state placeholder, and click callbacks
- Add `ImageLightbox` component wrapping YARL with zoom and thumbnail plugins for fullscreen image browsing
- Add unit tests for both components

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm test:run` passes (12 tests)
- [x] `pnpm build` passes
- [ ] Manual: verify carousel swipe on mobile viewport (Chrome DevTools)
- [ ] Manual: verify lightbox zoom, keyboard nav, swipe between images