### PR TITLE
Increase base font size for readability

### DIFF
--- a/src/components/trove-logo.tsx
+++ b/src/components/trove-logo.tsx
@@ -88,14 +88,14 @@ function TroveLogo({
       )}
     >
       <TroveFrameIcon
-        className={cn("text-primary", layout === "horizontal" ? "h-8" : "h-12")}
+        className={cn("text-primary", layout === "horizontal" ? "h-8" : "h-14")}
       />
       <div className="flex flex-col items-center gap-1">
-        <span className="text-primary font-serif text-2xl font-light tracking-[0.35em] uppercase">
+        <span className="text-primary font-serif text-4xl font-light tracking-[0.35em] uppercase">
           Trove
         </span>
         {showTagline && (
-          <span className="text-primary/85 font-serif text-xs font-light tracking-[0.4em] uppercase">
+          <span className="text-primary/85 font-serif text-sm font-light tracking-[0.4em] uppercase">
             Collection Management
           </span>
         )}

--- a/src/index.css
+++ b/src/index.css
@@ -119,6 +119,10 @@
 }
 
 @layer base {
+  html {
+    font-size: 106.25%; /* 17px base — slightly larger for readability */
+  }
+
   * {
     @apply border-border;
   }


### PR DESCRIPTION
## Summary

- Set root `font-size` to 106.25% (17px instead of default 16px), giving a subtle bump to all rem-based sizes across the app
- Enlarge the landing page "Trove" logo text from `text-2xl` to `text-4xl` and tagline from `text-xs` to `text-sm`
- Scale up the logo icon to match (`h-12` → `h-14` in vertical layout)

## Test plan

- [ ] Browse all pages — text should feel slightly larger but not oversized
- [ ] Landing page hero — "Trove" and "Collection Management" should be noticeably larger
- [ ] Verify no layout breaks from the size increase (dialogs, cards, forms)