### PR TITLE
Fix tag filter and add filter labels

### DIFF
--- a/src/pages/collections/collection-detail-page.tsx
+++ b/src/pages/collections/collection-detail-page.tsx
@@ -159,7 +159,7 @@ export function CollectionDetailPage() {
             </div>
 
             {/* Filters */}
-            <div className="mb-4 flex flex-wrap items-center gap-3">
+            <div className="mb-4 flex flex-wrap items-end gap-3">
               <div className="relative min-w-[200px] flex-1">
                 <Search className="text-muted-foreground absolute top-2.5 left-2.5 h-4 w-4" />
                 <Input


### PR DESCRIPTION
## Summary

- Fix "All tags" selection passing literal `"all"` to the API instead of clearing the filter
- Add subtle "Tag" and "Sort" labels above the filter selects for clarity

## Test plan

- [ ] Select a specific tag — items filter correctly
- [ ] Select "All tags" — all items show (filter cleared)
- [ ] Verify "Tag" and "Sort" labels appear above the selects