### PR TITLE
Update hosting references from Railway to Google Cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ dist-ssr
 
 # TypeScript
 *.tsbuildinfo
+
+# Local Netlify folder
+.netlify

--- a/src/pages/privacy-policy/privacy-policy-page.tsx
+++ b/src/pages/privacy-policy/privacy-policy-page.tsx
@@ -110,7 +110,8 @@ export function PrivacyPolicyPage() {
               <strong>Google OAuth:</strong> For optional sign-in authentication
             </li>
             <li>
-              <strong>Google Cloud:</strong> For hosting our backend and database
+              <strong>Google Cloud:</strong> For hosting our backend and
+              database
             </li>
             <li>
               <strong>Netlify:</strong> For hosting our frontend application

--- a/src/pages/privacy-policy/privacy-policy-page.tsx
+++ b/src/pages/privacy-policy/privacy-policy-page.tsx
@@ -110,7 +110,7 @@ export function PrivacyPolicyPage() {
               <strong>Google OAuth:</strong> For optional sign-in authentication
             </li>
             <li>
-              <strong>Railway:</strong> For hosting our backend and database
+              <strong>Google Cloud:</strong> For hosting our backend and database
             </li>
             <li>
               <strong>Netlify:</strong> For hosting our frontend application


### PR DESCRIPTION
## Summary
- Update privacy policy: third-party service provider changed from Railway to Google Cloud
- Add `.netlify` to `.gitignore` (local Netlify CLI state folder)

Also updated Netlify env var `VITE_API_URL` to point to the new Cloud Run URL and set `OPENAPI_URL` GitHub Actions variable for CI. These are environment-level changes, not code changes.

## Test plan
- [ ] Verify privacy policy page renders correctly
- [ ] Verify API calls from frontend hit the new Cloud Run endpoint