### PR TITLE
ci: make the type check actually check types, and build what ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,14 @@ jobs:
         run: pnpm format:check
 
       - name: Type check
-        run: pnpm tsc --noEmit
+        run: pnpm typecheck
 
       - name: Test
         run: pnpm test:run
+
+      # Type checking can't catch bundler-level failures, so build what ships.
+      - name: Build
+        run: pnpm build
 
   # Verifies that generated API types are up-to-date with the backend
   # Requires OPENAPI_URL to be set (e.g., to a staging backend)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "pnpm run generate-routes && tsc -b && vite build",
     "generate-api": "orval",
     "lint": "eslint .",
+    "typecheck": "tsc -b --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "preview": "vite preview",


### PR DESCRIPTION
## Problem

CI's "Type check" step runs `pnpm tsc --noEmit`. **It checks zero files and always exits 0.**

`tsconfig.json` here is a solution-style config — `"files": []` plus `references` to `tsconfig.app.json` and `tsconfig.node.json`. Running `tsc --noEmit` against it type-checks nothing. And with no build step in the pipeline, there's no `tsc -b` anywhere in CI either.

Net effect: **this repo has had no type checking in CI at all.** Any type error in `src/` merges green.

## Verification

Planted `export const p: number = "nope"` in `src/`:

| command | result |
|---|---|
| `pnpm tsc --noEmit` (old) | exit 0 — **missed it** |
| `pnpm typecheck` (new) | non-zero — **caught it** |

## Change

- `package.json` — add `"typecheck": "tsc -b --noEmit"`
- `.github/workflows/ci.yml` — `pnpm tsc --noEmit` → `pnpm typecheck`
- `.github/workflows/ci.yml` — add a `Build` step

`tsc -b --noEmit` is the invocation that covers **both** referenced projects; `tsc -p tsconfig.app.json --noEmit` silently misses `vite.config.ts`.

The `Build` step is separate on purpose: type checking cannot catch bundler-level failures. The `@` alias is declared in the tsconfigs *and* in the vite config — TypeScript reads one pair, Vite the other — so drift between them type-checks clean and fails only at build.

## Risk

Low. The repo is already clean — lint, format, typecheck, test and build all pass locally on this branch, so this turns the gate on without a backlog to clear first.

Same change as `ag-tech-group/web-template#41` and `#44`, which this repo was scaffolded from before those landed.
