### PR TITLE
Fix missing localStorage in test environment

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -13,6 +13,39 @@ afterEach(() => {
   cleanup()
 })
 
+// Mock localStorage — jsdom doesn't reliably provide window.localStorage
+// under newer Node versions with the experimental native Web Storage API.
+class LocalStorageMock implements Storage {
+  private store = new Map<string, string>()
+  get length() {
+    return this.store.size
+  }
+  clear() {
+    this.store.clear()
+  }
+  getItem(key: string) {
+    return this.store.get(key) ?? null
+  }
+  key(index: number) {
+    return Array.from(this.store.keys())[index] ?? null
+  }
+  removeItem(key: string) {
+    this.store.delete(key)
+  }
+  setItem(key: string, value: string) {
+    this.store.set(key, String(value))
+  }
+}
+const localStorageMock = new LocalStorageMock()
+Object.defineProperty(window, "localStorage", {
+  writable: true,
+  value: localStorageMock,
+})
+Object.defineProperty(globalThis, "localStorage", {
+  writable: true,
+  value: localStorageMock,
+})
+
 // Mock window.scrollTo
 window.scrollTo = vi.fn()
 


### PR DESCRIPTION
## Summary
- Every test that rendered `ThemeProvider` was crashing with `Cannot read properties of undefined (reading 'getItem')` — jsdom (`^26.0.0`) isn't reliably providing `window.localStorage` under newer Node versions that ship an experimental native Web Storage API, so `localStorage` resolves to `undefined` in the test environment
- Adds a small in-memory `localStorage` mock to `src/test/setup.ts`, matching the existing pattern already used there for `matchMedia`, `ResizeObserver`, and `IntersectionObserver`
- Unrelated to #53 (that issue is about `orval`/CI type-check verification for the generated API client) — this is a separate, pre-existing test-environment gap

## Test plan
- [x] `pnpm test:run` — all 15 tests pass (previously 5 failures across `home-page.test.tsx` and `all-items-page.test.tsx`)
- [x] `pnpm lint`, `pnpm format`, `pnpm typecheck`, `pnpm build` all pass